### PR TITLE
fix(SchoolQuizScreen): define html charset and document initial-scale

### DIFF
--- a/Millennium/1-frontend/2-questionarios/3-SchoolQuizScreen/SchoolQuizScreen.html
+++ b/Millennium/1-frontend/2-questionarios/3-SchoolQuizScreen/SchoolQuizScreen.html
@@ -2,6 +2,9 @@
 <html lang="pt-br">
 
 <head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet"
     integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
@@ -14,8 +17,9 @@
     crossorigin="anonymous" referrerpolicy="no-referrer" />
 
 
-    <!--adição no head*//-->
+  <!--adição no head*//-->
 </head>
+
 <body style="margin: 20px; font-family: 'Raleway', sans-serif;">
   <div class="container-fluid" id="topo-tela">
     <div class="row m-auto">
@@ -93,24 +97,23 @@
 
           </div>
         </div>
-          <div style="width: 445px; height: 120px;">
-            <p class="w-44 h-12 text-2xl font-bold leading-10 text-center text-gray-400">Observações:</p>
-            <div class="bg-gray-200" style="width: 445px; height: 74px;" />
-            <div
+        <div style="width: 445px; height: 120px;">
+          <p class="w-44 h-12 text-2xl font-bold leading-10 text-center text-gray-400">Observações:</p>
+          <div class="bg-gray-200" style="width: 445px; height: 74px;" />
+          <div </label>
+            </p>
+            <textarea class="container-fluid" id="w3review" name="w3review" rows="4" cols="50"></textarea>
+            <br>
+            </form>
+          </div>
           </label>
-        </p>
-          <textarea  class="container-fluid" id="w3review" name="w3review" rows="4" cols="50"></textarea>
-          <br>
-        </form>
-          </div>
-        </label>
-          </div>
         </div>
-        </p>
       </div>
-      <p align="right">
-        <button id="button4" type="button4">Próxima</button>
+      </p>
     </div>
+    <p align="right">
+      <button id="button4" type="button4">Próxima</button>
+  </div>
   </div>
   </div>
 </body>


### PR DESCRIPTION
The current HTML document, doesn't contain any charsete or initial-scale definitions. This leads to characters either breaking or disappearing. This PR adds the necessary definitions.

![image](https://user-images.githubusercontent.com/20153552/168195424-a6f124d9-9d81-4774-935b-067c85f286ab.png)
![image](https://user-images.githubusercontent.com/20153552/168195436-3bb0ef76-15a6-4ae3-a06c-5ae7b54d0757.png)
